### PR TITLE
chore(deps): consolidate dependabot updates

### DIFF
--- a/ValidDotNet.Tests.Unit/ValidDotNet.Tests.Unit.csproj
+++ b/ValidDotNet.Tests.Unit/ValidDotNet.Tests.Unit.csproj
@@ -17,7 +17,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector" Version="8.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/ValidDotNet.Tests.Unit/ValidDotNet.Tests.Unit.csproj
+++ b/ValidDotNet.Tests.Unit/ValidDotNet.Tests.Unit.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="7.2.0" />
+        <PackageReference Include="FluentAssertions" Version="7.2.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/ValidDotNet.Tests.Unit/ValidDotNet.Tests.Unit.csproj
+++ b/ValidDotNet.Tests.Unit/ValidDotNet.Tests.Unit.csproj
@@ -11,7 +11,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="7.2.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary

Consolidates all open Dependabot PRs into a single update:

- Bump FluentAssertions from 7.2.0 to 7.2.1
- Bump coverlet.collector from 6.0.4 to 8.0.0
- Bump Microsoft.NET.Test.Sdk from 18.0.1 to 18.3.0

Supersedes #25, #26, #27.